### PR TITLE
Handle tools with no description

### DIFF
--- a/completion.jinja
+++ b/completion.jinja
@@ -2,9 +2,11 @@
 # ----------------------------------------------------------------------------------------
 # Zsh completion file for {{ tool.name }}
 #
+{% if tool.description %}
 {% for line in tool.description.splitlines() %}
 # {{ line }}
 {% endfor %}
+{% endif %}
 #
 # This file was generated with help from Zargparse (https://github.com/ctil/zargparse)
 # ----------------------------------------------------------------------------------------


### PR DESCRIPTION
My previous contribution to split on newlines fails if there is no description at all.

```py
Traceback (most recent call last):
  File "/Users/heapcrash/github.com/zargparse/zargparse.py", line 199, in <module>
    main(arguments.file_path)
  File "/Users/heapcrash/github.com/zargparse/zargparse.py", line 190, in main
    runpy.run_path(file_path, run_name='__main__')
  File "/AppleInternal/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 265, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/AppleInternal/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/AppleInternal/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/heapcrash/.zprezto/modules/code-audit-helpers/radar-tools/bin/commit-to-url", line 80, in <module>
    main(**vars(p.parse_args()))
  File "/Users/heapcrash/github.com/zargparse/zargparse.py", line 181, in fake_parse_args
    f.write(template.render(tool=analyzer.tool))
  File "/Users/heapcrash/Library/Python/3.8/lib/python/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/Users/heapcrash/Library/Python/3.8/lib/python/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/Users/heapcrash/Library/Python/3.8/lib/python/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/heapcrash/Library/Python/3.8/lib/python/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 5, in <module>
jinja2.exceptions.UndefinedError: 'None' has no attribute 'splitlines'
```